### PR TITLE
Updated CustomDraggable

### DIFF
--- a/src/components/CustomDraggable.js
+++ b/src/components/CustomDraggable.js
@@ -3,8 +3,8 @@ import Draggable from 'react-draggable';
 class CustomDraggable extends Draggable {
   componentWillReceiveProps(nextProps) {
     const newState = {
-      clientX: nextProps.start.x,
-      clientY: nextProps.start.y,
+      x: nextProps.start.x,
+      y: nextProps.start.y,
     }
     this.setState(newState);
   }


### PR DESCRIPTION
changes made to fix the incorrect slew that was occurring when selecting tabs to drag.  This will now ensure that the beginning position is always 0 and always under the cursor.